### PR TITLE
Updated to escape file paths.

### DIFF
--- a/lib/demeteorizer.js
+++ b/lib/demeteorizer.js
@@ -6,6 +6,14 @@ var fs = require('fs'),
     path = require('path'),
     FsTools = require('fs-tools');
 
+//
+// Escape spaces out of a path.
+//
+var escapePath = function(path) {
+  if (!path || path.length === 0) return path;
+  return path.replace(/ /g, '\\ ');
+}
+
 //--------------------------------------------------------------------------------------------------
 var Demeteorizer = function() {
 
@@ -89,7 +97,7 @@ Demeteorizer.prototype.bundle = function(input, bundle, callback) {
     cmd = 'mrt';
   }
 
-  exec('cd ' + input + ' && ' + cmd + ' bundle ' + path.basename(bundle), function(err, stdout, stderr) {
+  exec('cd ' + escapePath(input) + ' && ' + cmd + ' bundle ' + escapePath(path.basename(bundle)), function(err, stdout, stderr) {
 
     if(stdout) {
       self.emit('progress', stdout);
@@ -115,7 +123,7 @@ Demeteorizer.prototype.extract = function(bundle, output, callback) {
 
   self.emit('progress', 'Extracting bundle.');
 
-  exec('tar -C ' + output + ' -xf ' + bundle, function(err, stdout, stderr) {
+  exec('tar -C ' + escapePath(output) + ' -xf ' + escapePath(bundle), function(err, stdout, stderr) {
 
     if(stdout) {
       self.emit('progress', stdout);
@@ -130,7 +138,7 @@ Demeteorizer.prototype.extract = function(bundle, output, callback) {
     }
 
     // Move all content up from ./bundle to the output folder.
-    var command = 'mv -i ' + path.join(output, 'bundle/*') + ' ' + output;
+    var command = 'mv -i ' + escapePath(path.join(output, 'bundle/*')) + ' ' + escapePath(output);
 
     exec(command, function(err, stdout, stderr) {
       if(err) {


### PR DESCRIPTION
This corrects an issue where paths with spaces would fail to properly
run demeteorizer.

Closes #28 
