### PR TITLE
Added prerelease flag.

### DIFF
--- a/cli/demeteorizer.js
+++ b/cli/demeteorizer.js
@@ -5,10 +5,11 @@ var program = require('commander'),
 program
   .version(require('../package.json').version)
   .option('-o, --output <path>', 'Output folder for converted application. Defaults to ./.demeteorized.')
-  .option('-n, --node_version <version>', 'The required version of node [v0.10.22]', 'v0.10.22')
+  .option('-n, --node_version <version>', 'The required version of node [v0.10.22].', 'v0.10.22')
   .option('-r, --release <version>', 'The Meteor version. Defaults to latest installed.')
   .option('-t, --tarball <path>', 'Output tarball path. If specified, creates a tar.gz of demeteorized application instead of directory.')
   .option('-a, --app_name <name>', 'Value to put in the package.json name field. Defaults to the current directory name.')
+  .option('-p, --prerelease', 'Ignore Meteor prerelease warnings when running bundle.', false)
   .parse(process.argv);
 
 var output = program.output;
@@ -16,6 +17,7 @@ var node_version = program.node_version;
 var release = program.release;
 var tarball = program.tarball;
 var appName = program.app_name;
+var prerelease = program.prerelease;
 
 var input = process.cwd();
 
@@ -37,7 +39,7 @@ demeteorizer.on('progress', function(msg) {
   console.log(msg);
 });
 
-demeteorizer.convert(input, output, node_version, release, tarball, appName, function(err) {
+demeteorizer.convert(input, output, node_version, release, tarball, appName, prerelease, function(err) {
   if(err) {
     console.log('ERROR: ' + err);
   }

--- a/lib/demeteorizer.js
+++ b/lib/demeteorizer.js
@@ -22,7 +22,7 @@ var Demeteorizer = function() {
 util.inherits(Demeteorizer, EventEmitter);
 
 //--------------------------------------------------------------------------------------------------
-Demeteorizer.prototype.convert = function(input, output, nodeVersion, release, tarball, appName, callback) {
+Demeteorizer.prototype.convert = function(input, output, nodeVersion, release, tarball, appName, prerelease, callback) {
 
   var self = this;
 
@@ -40,7 +40,7 @@ Demeteorizer.prototype.convert = function(input, output, nodeVersion, release, t
       self.setupOutputFolder(output, callback);
     },
     function(callback) {
-      self.bundle(input, self.paths.bundle, release, callback);
+      self.bundle(input, self.paths.bundle, release, prerelease, callback);
     },
     function(callback) {
       self.extract(self.paths.bundle, output, callback);
@@ -92,7 +92,7 @@ Demeteorizer.prototype.setupOutputFolder = function(output, callback) {
 };
 
 //--------------------------------------------------------------------------------------------------
-Demeteorizer.prototype.bundle = function(input, bundle, release, callback) {
+Demeteorizer.prototype.bundle = function(input, bundle, release, prerelease, callback) {
 
   var self = this;
   var cmd = 'meteor';
@@ -114,7 +114,8 @@ Demeteorizer.prototype.bundle = function(input, bundle, release, callback) {
       self.emit('progress', stdout);
     }
 
-    if(stderr) {
+    // Only break on stderr output if not a prerelease run.
+    if(stderr && !prerelease) {
       return callback(stderr);
     }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "keywords": [
     "meteor"
   ],
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": "Modulus <support@modulus.io>",
   "maintainers": [
     "Brandon Cannaday <brandon@modulus.io>"


### PR DESCRIPTION
When the prerelease flag is enabled, any warnings written to stderr while running meteor's bundle command are ignored. These warnings inform the user that they are running a prerelease version of Meteor.

Closes #49.
