### PR TITLE
Attempt to use the resolved version of a package, if it exists

### DIFF
--- a/lib/demeteorizer.js
+++ b/lib/demeteorizer.js
@@ -251,12 +251,11 @@ Demeteorizer.prototype.findDependencies = function(output, callback) {
           // Set the dependency ignoring the dependency on npm which is
           // bundled with node.
           if(contents.name !== "npm") {
-            dependencies[contents.name] = contents.version;
+            // ensure we get the version npm actually downloaded
+            dependencies[contents.name] = contents._resolved || contents.version;
             count++;
           }
 
-          // ensure we get the version npm actually downloaded
-          dependencies[contents.name] = contents._resolved || contents.version;
         }
       }
     });


### PR DESCRIPTION
I ran into issue #48 when trying to deploy an app which depended on unpublished npm packages. I've patched demeteorizer to use the `_released` property.

Are there issues with the way I've solved this issue? If not this closes #48.
