### PR TITLE
Added basic NodeJitsu support

### DIFF
--- a/cli/demeteorizer.js
+++ b/cli/demeteorizer.js
@@ -9,6 +9,8 @@ program
   .option('-r, --release <version>', 'The Meteor version. Defaults to latest installed.')
   .option('-t, --tarball <path>', 'Output tarball path. If specified, creates a tar.gz of demeteorized application instead of directory.')
   .option('-a, --app_name <name>', 'Value to put in the package.json name field. Defaults to the current directory name.')
+  .option('-s, --subdomain <subdomain>', 'The NodeJitsu subdomain for this app.')
+  .option('-d, --domains <domains>', 'Comma separated list of custom domains for NodeJitsu.')
   .option('-p, --prerelease', 'Ignore Meteor prerelease warnings when running bundle.', false)
   .option('-d, --debug', 'Bundle in debug mode (don\'t minify, etc).', false)
   .parse(process.argv);
@@ -18,6 +20,8 @@ var node_version = program.node_version;
 var release = program.release;
 var tarball = program.tarball;
 var appName = program.app_name;
+var subdomain = program.subdomain;
+var domains = program.domains;
 var prerelease = program.prerelease;
 var debug = program.debug;
 
@@ -41,7 +45,7 @@ demeteorizer.on('progress', function(msg) {
   console.log(msg);
 });
 
-demeteorizer.convert(input, output, node_version, release, tarball, appName, prerelease, debug, function(err) {
+demeteorizer.convert(input, output, node_version, release, tarball, appName, subdomain, domains, prerelease, debug, function(err) {
   if(err) {
     console.log('ERROR: ' + err);
   }

--- a/lib/demeteorizer.js
+++ b/lib/demeteorizer.js
@@ -22,7 +22,7 @@ var Demeteorizer = function() {
 util.inherits(Demeteorizer, EventEmitter);
 
 //--------------------------------------------------------------------------------------------------
-Demeteorizer.prototype.convert = function(input, output, nodeVersion, release, tarball, appName, prerelease, debug, callback) {
+Demeteorizer.prototype.convert = function(input, output, nodeVersion, release, tarball, appName, subdomain, domains, prerelease, debug, callback) {
 
   var self = this;
 
@@ -49,7 +49,7 @@ Demeteorizer.prototype.convert = function(input, output, nodeVersion, release, t
       self.findDependencies(output, callback);
     },
     function(callback) {
-      self.createPackageJSON(self.dependencies, input, output, nodeVersion, appName, callback);
+      self.createPackageJSON(self.dependencies, input, output, nodeVersion, appName, subdomain, domains, callback);
     },
     function(callback) {
       if (fs.existsSync(self.paths.old_server)) {
@@ -269,7 +269,7 @@ Demeteorizer.prototype.findDependencies = function(output, callback) {
 };
 
 //--------------------------------------------------------------------------------------------------
-Demeteorizer.prototype.createPackageJSON = function(dependencies, input, output, nodeVersion, appName, callback) {
+Demeteorizer.prototype.createPackageJSON = function(dependencies, input, output, nodeVersion, appName, subdomain, domains, callback) {
 
   this.emit('progress', 'Creating package.json file.');
 
@@ -294,6 +294,14 @@ Demeteorizer.prototype.createPackageJSON = function(dependencies, input, output,
   };
   packageJSON.engines = nodeVersionJSON;
   packageJSON.dependencies = dependencies;
+  
+  if(subdomain) {
+    packageJSON.subdomain = subdomain;
+  }
+  
+  if(domains) {
+    packageJSON.domains = domains.split(',');
+  }
 
   fs.writeFileSync(this.paths.package_json, JSON.stringify(packageJSON, undefined, 2));
 


### PR DESCRIPTION
Deploying to NodeJistu can be a bit tedious because you need to update the package.json everytime you run demeteorize. I've added 2 options to support basic support to deploy to NodeJistu:

```
demeteorizer -s jitsu-subdomain -d www.jit.su,jit.su
```
