### PR TITLE
demeteorizer should exit with errror code if error occurs

### DIFF
--- a/cli/demeteorizer.js
+++ b/cli/demeteorizer.js
@@ -50,6 +50,7 @@ demeteorizer.convert(
   function(err) {
     if(err) {
       console.log('ERROR: ' + err);
+      process.exit(1);
     }
     else {
       console.log('Demeteorization complete.');


### PR DESCRIPTION
i am using demeteorizer in gruntjs.
when demeteorizer fails an exit  code different from 0 should be returned in order to inform the caller about the error.
with this changes, everything works as expected

here is the gruntjs code:

```
shell: {
            demeteorizer : {
                command : 'demeteorizer',
                options: {
                    execOptions: {
                        cwd: '<%= path  %>',
                        failOnError: true

                    }
                }
            }
        },
```

and how gruntjs stops when demeteorizer returns  error code 1

```
myo@pingu:~/Dev/code/XX/tools/deploy$ grunt shell
Running "shell:demeteorizer" (shell) task
Input: /home/myo/Dev/code/XX/src/XXX
Output: /home/myo/Dev/code/XX/src/XXX/.demeteorized
Determining Meteor version...
Meteor version: 0.9.1.1

Output folder exists, deleting...
ERROR: Error: EACCES, unlink '/home/myo/Dev/code/XX/src/XXX/.demeteorized/programs/server/node_modules/.bin/semver'
Warning: Command failed:  Use --force to continue.

Aborted due to warnings.

```
