### PR TITLE
Fix https://github.com/onmodulus/demeteorizer/issues/70

### DIFF
--- a/lib/demeteorizer.js
+++ b/lib/demeteorizer.js
@@ -221,7 +221,7 @@ Demeteorizer.prototype.bundle = function(context, callback) {
  */
 
 Demeteorizer.prototype.findDependenciesInFolder = function(folder, inNodeModulesFolder, context) {
-  
+
   var files = fs.readdirSync(folder);
   var self = this;
 
@@ -277,8 +277,8 @@ Demeteorizer.prototype.filterDep = function(name, version) {
 
   var filtered = { name: name, version: version };
 
-  // If the version is 0.0.0, just skip it.
-  if(version === '0.0.0') {
+  // If the version starts with '0.0.0', just skip it.
+  if(typeof version === 'undefined' || version.indexOf('0.0.0') === 0) {
     filtered = null;
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -27,3 +27,18 @@ projects.forEach(function(project) {
     })
   })
 });
+
+
+// Test filterDep
+
+// Test filterDep for '0.0.0' and '0.0.0-unreleaseable'
+['0.0.0','0.0.0-unreleaseable', undefined].forEach(function(ver){
+  describe('Invalid Dep Version', function(){
+    describe(ver, function(){
+      it('should return null', function(done){
+        assert(demeteorizer.filterDep('somepackage', ver) === null);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
@InconceivableDuck The issue was rooted in scraperjs' use of 'shoe', which has a bundled package with version '0.0.0-unreleasable'. Seems reasonable to broaden the existing exclusion of packages with version '0.0.0' to catch the new case as well. To make it generic, I just check to see if it starts with '0.0.0'.

Thanks.
