### PR TITLE
Adds the ability to filter invalid modules

### DIFF
--- a/lib/demeteorizer.js
+++ b/lib/demeteorizer.js
@@ -6,13 +6,19 @@ var fs = require('fs'),
     path = require('path'),
     FsTools = require('fs-tools'),
     semver = require('semver');
-//
-// Escape spaces out of a path.
-//
+
+/**
+ * Escapes spaces out of the specified path.
+ * @param {String} path The path to escape.
+ */
 var escapePath = function(path) {
   if (!path || path.length === 0) return path;
   return path.replace(/ /g, '\\ ');
 };
+
+const modulesNotInRegistry = [
+  'aws-sdk-browser-builder'
+];
 
 //--------------------------------------------------------------------------------------------------
 var Demeteorizer = function() {
@@ -221,7 +227,7 @@ Demeteorizer.prototype.bundle = function(context, callback) {
  */
 
 Demeteorizer.prototype.findDependenciesInFolder = function(folder, inNodeModulesFolder, context) {
-  
+
   var files = fs.readdirSync(folder);
   var self = this;
 
@@ -247,7 +253,7 @@ Demeteorizer.prototype.findDependenciesInFolder = function(folder, inNodeModules
       }
     }
     else {
-      if(file === "package.json") {
+      if(file === 'package.json') {
         var packageJson = JSON.parse(fs.readFileSync(path.join(folder, file)));
         var filtered = self.filterDep(packageJson.name, packageJson._resolved || packageJson.version);
         if(filtered) {
@@ -271,20 +277,26 @@ Demeteorizer.prototype.findDependenciesInFolder = function(folder, inNodeModules
  * Changes, removes, etc dependencies.
  * @param {String} name The name of the dep.
  * @param {String} version The version of the dep.
- * @returns {Object} Object with name, version properties adjusted. Or null if dep is to be removed.
+ * @returns {Object} Object with name, version properties adjusted. Or null if
+ *    dependency is to be removed.
  */
 Demeteorizer.prototype.filterDep = function(name, version) {
 
   var filtered = { name: name, version: version };
 
-  // If the version is 0.0.0, just skip it.
-  if(version === '0.0.0') {
+  // If the version starts with '0.0.0', just skip it.
+  if (version === undefined || version.indexOf('0.0.0') === 0) {
     filtered = null;
   }
 
   // The 0.4.12 usage module has trouble compile. Switch it to 0.4.13.
-  if(name === 'usage' && version === '0.4.12') {
+  if (name === 'usage' && version === '0.4.12') {
     filtered.version = '0.4.13';
+  }
+
+  // Filter out any modules that are not present in the registry.
+  if (modulesNotInRegistry.indexOf(name) >= 0) {
+    filtered = null;
   }
 
   return filtered;
@@ -337,7 +349,7 @@ Demeteorizer.prototype.createPackageJSON = function(context, callback) {
   packageJSON.version = '0.0.1';
   packageJSON.main = 'main.js';
   packageJSON.scripts = {
-    start: "node main.js"
+    start: 'node main.js'
   };
   packageJSON.dependencies = context.dependencies;
 
@@ -362,7 +374,7 @@ Demeteorizer.prototype.deleteNodeModulesDirs = function(context, callback) {
 };
 
 /**
- * Deletes node_modules folders. Recursives looks through all folders.
+ * Deletes node_modules folders. Recursively looks through all folders.
  * @param {String} folder The folder to look in.
  */
 Demeteorizer.prototype.deleteNodeModulesDir = function(folder) {
@@ -438,7 +450,7 @@ Demeteorizer.prototype.createTarball = function(context, callback) {
 
     callback();
   });
-}
+};
 
 /**
  * Deletes the output directory if the tarball option is specified.
@@ -454,6 +466,6 @@ Demeteorizer.prototype.deleteDirectory = function(context, callback) {
   this.emit('progress', 'Deleting bundle directory.');
 
   FsTools.remove(context.options.output, callback);
-}
+};
 
 module.exports = new Demeteorizer();

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,6 @@
 // To run: > cd test && mocha --timeout 60000 test.js
 
 var demeteorizer = require('../lib/demeteorizer'),
-    path = require('path'),
     assert = require('assert');
 
 var projects = [
@@ -20,10 +19,22 @@ projects.forEach(function(project) {
     describe(project, function() {
       it('should convert without error', function(done) {
         demeteorizer.convert(project, project + '_converted', 'v0.8.11', null, null, null, false, false, done);
-      })
+      });
       it('should convert without error (in debug mode)', function(done) {
         demeteorizer.convert(project, project + '_debug_converted', 'v0.8.11', null, null, null, false, true, done);
-      })
-    })
-  })
+      });
+    });
+  });
+});
+
+// Test filterDep for '0.0.0' and '0.0.0-unreleaseable'
+['0.0.0','0.0.0-unreleaseable', undefined].forEach(function(ver){
+  describe('Invalid Dep Version', function(){
+    describe(ver, function(){
+      it('should return null', function(done){
+        assert(demeteorizer.filterDep('somepackage', ver) === null);
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
Adds a constant that includes the names of modules that Meteor uses
which are not present in the npm registry. These modules are skipped
when building the package.json for the project.

Closes #70 #71 and #73

Includes fixes plucked from #73 (thanks @BigDSK <3).
