### PR TITLE
Updated to correctly handle errors from Meteor

### DIFF
--- a/cli/demeteorizer.js
+++ b/cli/demeteorizer.js
@@ -45,7 +45,7 @@ demeteorizer.convert(
   options,
   function (err) {
     if (err) {
-      console.log('ERROR: ' + err);
+      console.log('Demeteorization failed:', err.message);
       process.exit(1);
     } else {
       console.log('Demeteorization complete.');

--- a/lib/demeteorizer.js
+++ b/lib/demeteorizer.js
@@ -87,23 +87,22 @@ Demeteorizer.prototype.setupPaths = function (options) {
  */
 Demeteorizer.prototype.getMeteorVersion = function (context, callback) {
 
-  var self = this;
-
-  self.emit('progress', 'Determining Meteor version...');
+  this.emit('progress', 'Determining Meteor version...');
 
   childProcess.exec('meteor --version', function (err, stdout, stderr) {
     if (err || stderr || !stdout) {
-      self.emit('error', 'Could not determine Meteor version. Please ensure Meteor tools are installed.');
-      return callback(new Error('Could not determine Meteor version.'));
+      return callback(new Error(
+        'Could not determine Meteor version. Make sure that Meteor is installed.'
+      ));
     }
 
     var version = stdout.split(' ')[1].replace(/\n/, '');
     var versionParts = version.split('.');
     context.meteorVersion = versionParts[0] + '.' + versionParts[1] + '.x';
 
-    self.emit('progress', 'Meteor version: ' + version);
+    this.emit('progress', 'Meteor version: ' + version);
     callback(null, context.meteorVersion);
-  });
+  }.bind(this));
 };
 
 

--- a/test/demeteorizer-test.js
+++ b/test/demeteorizer-test.js
@@ -16,7 +16,6 @@ var context = { options: { input: '' } };
 describe('demeteorizer', function () {
 
   before(function () {
-    cpStub.exec = sinon.stub().yields(null, 'Meteor 0.9.9.2', '');
     fsStub.existsSync = sinon.stub().returns(true);
     fstStub.remove = sinon.stub();
   });
@@ -44,8 +43,22 @@ describe('demeteorizer', function () {
 
   describe('#getMeteorVersion', function () {
     it('should get the correct meteor version', function () {
+      cpStub.exec = sinon.stub().yields(null, 'Meteor 0.9.9.2', '');
+
       demeteorizer.getMeteorVersion(context, function () {
         context.meteorVersion.should.equal('0.9.x');
+      });
+    });
+
+    it('should return an error if meteor is not installed', function (done) {
+      cpStub.exec = sinon.stub().yields('command failed');
+
+      demeteorizer.getMeteorVersion(context, function (err) {
+        err.should.be.ok;
+        err.message.should.equal(
+          'Could not determine Meteor version. Make sure that Meteor is installed.'
+        );
+        done();
       });
     });
   });


### PR DESCRIPTION
The `getMeteorVersion` method would both return and emit errors if the
`Meteor --version` command failed. It will now only return the error
(since the event wasn't handled anyway) and the error has been updated
to reflect the problem.

Includes a test case for this scenario.

Closes #76.
