### PR TITLE
Show trace when error to understand it

### DIFF
--- a/cli/demeteorizer.js
+++ b/cli/demeteorizer.js
@@ -46,6 +46,7 @@ demeteorizer.convert(
   function (err) {
     if (err) {
       console.log('Demeteorization failed:', err.message || err);
+      console.trace();
       process.exit(1);
     } else {
       console.log('Demeteorization complete.');


### PR DESCRIPTION
Related to #78

I really think the trace should be shown in order to know what failed
and where it failed.
