### PR TITLE
Updated to allow extra output from meteor version

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -35,7 +35,7 @@
   "globalstrict"  : false,
   "iterator"      : false,
   "lastsemic"     : false,
-  "laxbreak"      : false,
+  "laxbreak"      : true,
   "laxcomma"      : true,
   "loopfunc"      : false,
   "multistr"      : false,

--- a/lib/demeteorizer.js
+++ b/lib/demeteorizer.js
@@ -100,7 +100,18 @@ Demeteorizer.prototype.getMeteorVersion = function (context, callback) {
       ));
     }
 
-    var version = stdout.split(' ')[1].trim();
+    // Typical `$ meteor --version` output returns 2 pieces when split on \n
+    //    the version and an empty string.
+    // If the length of the split is more than 2, the output includes some extra
+    //    stuff so the return value should be based on the last line of text.
+    var versionLines = stdout.split('\n');
+    var versionText = versionLines.length > 2
+      ? versionLines[versionLines.length - 2]
+      : stdout;
+
+    // Split on space and take the second element because the version output is
+    //    `Meteor x.x.x.x`.
+    var version = versionText.split(' ')[1].trim();
     var versionParts = version.split('.');
     context.meteorVersion = versionParts[0] + '.' + versionParts[1] + '.x';
 

--- a/test/demeteorizer-test.js
+++ b/test/demeteorizer-test.js
@@ -43,7 +43,17 @@ describe('demeteorizer', function () {
 
   describe('#getMeteorVersion', function () {
     it('should get the correct meteor version', function () {
-      cpStub.exec = sinon.stub().yields(null, 'Meteor 0.9.9.2', '');
+      cpStub.exec = sinon.stub().yields(null, 'Meteor 0.9.9.2\n', '');
+
+      demeteorizer.getMeteorVersion(context, function () {
+        context.meteorVersion.should.equal('0.9.x');
+      });
+    });
+
+    it('should get the correct meteor version when extra output is present', function () {
+      var out =
+        'loading observatory: apollo\nloading observatory: galileo\nMeteor 0.9.2.2\n';
+      cpStub.exec = sinon.stub().yields(null, out, '');
 
       demeteorizer.getMeteorVersion(context, function () {
         context.meteorVersion.should.equal('0.9.x');


### PR DESCRIPTION
Handle the case where meteor outputs more than just the version of
meteor. Includes test cases with sample output.

Only modifies the functionality if extra output is detected; otherwise,
the existing logic remains.

Closes #80.
