### PR TITLE
Corrects an error with invalid package.json

### DIFF
--- a/lib/demeteorizer.js
+++ b/lib/demeteorizer.js
@@ -217,14 +217,12 @@ Demeteorizer.prototype.bundle = function (context, callback) {
 
 Demeteorizer.prototype.findDependenciesInFolder = function (folder, inNodeModulesFolder, context) {
 
-  var files = fs.readdirSync(folder);
-  var self = this;
-
-  files.forEach(function (file) {
+  fs.readdirSync(folder).forEach(function (file) {
     var stats = fs.statSync(path.join(folder, file));
     if (stats.isDirectory()) {
       var inNodeMod = false;
       var keepGoing = true;
+
       if (file === 'node_modules') {
         inNodeMod = true;
         if (inNodeModulesFolder) {
@@ -232,33 +230,39 @@ Demeteorizer.prototype.findDependenciesInFolder = function (folder, inNodeModule
         }
       }
 
-      // sockjs comes with example folders, remove.
+      // Skip the examples directory.
       if (file === 'examples') {
         keepGoing = false;
       }
 
       if (keepGoing) {
-        self.findDependenciesInFolder(path.join(folder, file), inNodeMod, context);
+        this.findDependenciesInFolder(path.join(folder, file), inNodeMod, context);
       }
     }
     else {
       if (file === 'package.json') {
-        var packageJson = JSON.parse(fs.readFileSync(path.join(folder, file)));
-        var filtered = self.filterDep(packageJson.name, packageJson._resolved || packageJson.version);
-        if (filtered) {
-          context.dependencies[filtered.name] = filtered.version;
-        }
-        if (packageJson.dependencies) {
-          Object.keys(packageJson.dependencies).forEach(function (dep) {
-            var filtered = self.filterDep(dep, packageJson.dependencies[dep]);
-            if (filtered) {
-              context.dependencies[filtered.name] = filtered.version;
-            }
-          });
+        var packageData = fs.readFileSync(path.join(folder, file));
+
+        // Test that the package.json contains data. There is a module that
+        //    includes a package.json fixture that is empty.
+        if (packageData.length > 0) {
+          var packageJson = JSON.parse(packageData);
+          var filtered = this.filterDep(packageJson.name, packageJson._resolved || packageJson.version);
+          if (filtered) {
+            context.dependencies[filtered.name] = filtered.version;
+          }
+          if (packageJson.dependencies) {
+            Object.keys(packageJson.dependencies).forEach(function (dep) {
+              var filtered = this.filterDep(dep, packageJson.dependencies[dep]);
+              if (filtered) {
+                context.dependencies[filtered.name] = filtered.version;
+              }
+            }.bind(this));
+          }
         }
       }
     }
-  });
+  }.bind(this));
 
 };
 


### PR DESCRIPTION
There is a module that includes a test fixture that is an empty
package.json file which demeteorizer attempts to parse which fails.

Each package.json file is now checked that it contains data and is
skipped if it does not.

Closes #69
