### PR TITLE
Updated to handle invalid Meteor versions

### DIFF
--- a/lib/demeteorizer.js
+++ b/lib/demeteorizer.js
@@ -153,9 +153,20 @@ Demeteorizer.prototype.getBundleCommand = function (context) {
 
   var smartJsonPath = path.join(context.options.input, 'smart.json');
 
-  if (semver.lte(context.meteorVersion.replace('x', '0'), '0.8.0') && fs.existsSync(smartJsonPath)) {
-    this.emit('progress', 'Found smart.json file, switching to Meteorite bundle.');
-    cmd = 'mrt';
+  // Ignore any errors when attempting to determine the version. Newer versions
+  //    of Meteor use invalid semantic versions; default to meteor bundle.
+  try {
+    if (semver.lte(context.meteorVersion.replace('x', '0'), '0.8.0')
+        && fs.existsSync(smartJsonPath)) {
+      this.emit(
+        'progress',
+        'Found smart.json file, switching to Meteorite bundle.');
+      cmd = 'mrt';
+    }
+  } catch (e) {
+    this.emit('progress', util.format(
+      'Warning: failed to parse version \'%s\'.',
+      context.meteorVersion));
   }
 
   return cmd;

--- a/spec/demeteorizer-spec.js
+++ b/spec/demeteorizer-spec.js
@@ -110,6 +110,11 @@ describe('demeteorizer lib', function () {
       context.meteorVersion = '0.8.x';
       demeteorizer.getBundleCommand(context).should.equal('mrt');
     });
+
+    it('should choose meteor bundle for invalid versions', function () {
+      context.meteorVersion = '1.0-rc.10';
+      demeteorizer.getBundleCommand(context).should.equal('meteor');
+    });
   });
 
   describe('#bundle', function () {


### PR DESCRIPTION
Newer versions of Meteor including the 1.0 release candidate use
invalid semantic versioning. This change will default to meteor's
bundle command if the version check fails.
