### PR TITLE
Dockerfile support so demeteorizer can be used to dockerize.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ compiled modules.
     -r, --release <version>       The Meteor version. Defaults to latest installed.
     -t, --tarball <path>          Output tarball path. If specified, creates a tar.gz of demeteorized application instead of directory.
     -a, --app_name <name>         Value to put in the package.json name field. Defaults to the current directory name.
+    -b, --base_image <image>      Add a Dockerfile to the output with the specified base image. An ONBUILD style image is recommended.
     -d, --debug                   Bundle in debug mode (don't minify, etc).
 
 ## Meteor 0.8.1 and Below

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -8,15 +8,17 @@ program
   .option('-r, --release <version>', 'The Meteor version. Defaults to latest installed.')
   .option('-t, --tarball <path>', 'Output tarball path. If specified, creates a tar.gz of demeteorized application instead of directory.')
   .option('-a, --app_name <name>', 'Value to put in the package.json name field. Defaults to the current directory name.')
+  .option('-b, --base_image <image>', 'Add a Dockerfile to the output with the specified base image. An ONBUILD style image is recommended.')
   .option('-d, --debug', 'Bundle in debug mode (don\'t minify, etc).', false)
   .parse(process.argv);
 
-var appName = program.app_name;
-var debug   = program.debug;
-var input   = process.cwd();
-var output  = program.output;
-var release = program.release;
-var tarball = program.tarball;
+var appName   = program.app_name;
+var debug     = program.debug;
+var input     = process.cwd();
+var output    = program.output;
+var release   = program.release;
+var tarball   = program.tarball;
+var baseImage = program.base_image;
 
 output = output || path.join(process.cwd(), '.demeteorized');
 
@@ -27,12 +29,13 @@ if (release) {
 demeteorizer.on('progress', console.log.bind(console));
 
 var options = {
-  appName : appName,
-  debug   : debug,
-  input   : input,
-  output  : output,
-  release : release,
-  tarball : tarball
+  appName   : appName,
+  debug     : debug,
+  input     : input,
+  output    : output,
+  release   : release,
+  tarball   : tarball,
+  baseImage : baseImage
 };
 
 demeteorizer.convert(

--- a/lib/demeteorizer.js
+++ b/lib/demeteorizer.js
@@ -38,6 +38,7 @@ util.inherits(Demeteorizer, EventEmitter);
  * @param {String} options.release The meteor release to use (e.g. 0.9.0.1).
  * @param {String} options.tarball Optional tarball path to put output.
  * @param {String} options.appName Optional application name to put in package.json.
+ * @param {String} options.baseImage Optional base image to create a Dockerfile
  * @param {Boolean} options.prerelease Whether to ignore warnings based on Meteor version.
  * @param {Boolean} options.debug Whether to run Meteor's bundle in debug mode.
  * @param {Function} callback Callback handling the response.
@@ -59,6 +60,7 @@ Demeteorizer.prototype.convert = function (options, callback) {
     this.bundle.bind(this, context),
     this.findDependencies.bind(this, context),
     this.createPackageJSON.bind(this, context),
+    this.createDockerfile.bind(this, context),
     this.deleteNodeModulesDirs.bind(this, context),
     this.deleteShrinkWraps.bind(this, context),
     this.createTarball.bind(this, context),
@@ -77,6 +79,7 @@ Demeteorizer.prototype.setupPaths = function (options) {
     old_node_modules : path.join(options.output, 'server', 'node_modules'),
     old_server       : path.join(options.output, 'server', 'server.js'),
     package_json     : path.join(options.output, 'package.json'),
+    dockerfile       : path.join(options.output, 'Dockerfile'),
     server           : path.join(options.output, 'programs', 'server', 'boot.js')
   };
 };
@@ -380,6 +383,29 @@ Demeteorizer.prototype.createPackageJSON = function (context, callback) {
   fs.writeFileSync(context.paths.package_json, JSON.stringify(packageJSON, null, 2));
 
   this.emit('progress', 'package.json file generation complete.');
+  callback();
+};
+
+/**
+ * Creates the Dockerfile.
+ * @param {Object} context Context for the convert.
+ * @param {Function} callback Callback handling the response.
+ */
+Demeteorizer.prototype.createDockerfile = function (context, callback) {
+
+  if (!context.options.baseImage) {
+    return callback();
+  }
+
+  this.emit('progress', 'Creating Dockerfile.');
+
+  var baseImage = context.options.baseImage;
+
+  var dockerFileContents = 'FROM ' + baseImage + '\nENV PORT 80\nEXPOSE 80\n';
+
+  fs.writeFileSync(context.paths.dockerfile, dockerFileContents);
+
+  this.emit('progress', 'Dockerfile generation complete.');
   callback();
 };
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "keywords": [
     "meteor"
   ],
-  "version": "2.0.4",
+  "version": "2.1.0",
   "author": "Modulus <support@modulus.io>",
   "maintainers": [
     "Brandon Cannaday <brandon@modulus.io>",
@@ -15,7 +15,8 @@
     "Bret Fisher <me@bfish.us>",
     "Matt Hernandez <matt@modulus.io>",
     "Tarang Patel <t@ran.gg>",
-    "Vincil Bishop <vincil.bishop@Vbishop.com>"
+    "Vincil Bishop <vincil.bishop@Vbishop.com>",
+    "Daniel Dent (https://www.danieldent.com/)"
   ],
   "license": "MIT",
   "repository": {

--- a/spec/demeteorizer-spec.js
+++ b/spec/demeteorizer-spec.js
@@ -145,6 +145,8 @@ describe('demeteorizer lib', function () {
         .equal('.demeteorized/server/server.js');
       test.package_json.should
         .equal('.demeteorized/package.json');
+      test.dockerfile.should
+        .equal('.demeteorized/Dockerfile');
       test.server.should
         .equal('.demeteorized/programs/server/boot.js');
     });


### PR DESCRIPTION
I'll soon be releasing a workflow which uses docker for meteor development and production environments. This pull request adds a feature which simplifies dockerizing a meteor app. I would be grateful if you could merge it; if you have any questions or would like some changes made, just let me know.
