### PR TITLE
Updated to specify the version of node

### DIFF
--- a/lib/demeteorizer.js
+++ b/lib/demeteorizer.js
@@ -370,6 +370,9 @@ Demeteorizer.prototype.createPackageJSON = function (context, callback) {
   packageJSON.scripts = {
     start: 'node main.js'
   };
+  // FIXME: this is a hack to avoid defaulting to node@0.10.34 which breaks some
+  //    timer code.
+  packageJSON.engines = { node: '0.10.33' };
   packageJSON.dependencies = context.dependencies;
 
   fs.writeFileSync(context.paths.package_json, JSON.stringify(packageJSON, null, 2));

--- a/spec/demeteorizer-spec.js
+++ b/spec/demeteorizer-spec.js
@@ -150,4 +150,18 @@ describe('demeteorizer lib', function () {
     });
   });
 
+  describe('#createPackageJSON', function () {
+    it('should create package.json with the correct fields', function () {
+      context.paths = {};
+      context.paths.package_json = './package.json';
+
+      fsStub.writeFileSync = function (path, data) {
+        path.should.equal('./package.json');
+        JSON.parse(data).engines.node.should.exist;
+      };
+
+      demeteorizer.createPackageJSON(context, new Function());
+    });
+  });
+
 });


### PR DESCRIPTION
Now adds the `engines` field to the generated package.json to avoid
using node@0.10.34 which has busted ass timers.
