### PR TITLE
Skip folders called samples

### DIFF
--- a/lib/demeteorizer.js
+++ b/lib/demeteorizer.js
@@ -238,7 +238,7 @@ Demeteorizer.prototype.findDependenciesInFolder = function (folder, inNodeModule
       }
 
       // Skip the examples directory.
-      if (file === 'examples') {
+      if (file === 'examples' || file === 'samples') {
         keepGoing = false;
       }
 


### PR DESCRIPTION
Some packages, like [facebook-node-sdk](https://github.com/Thuzi/facebook-node-sdk), use the convention of calling the examples folder `samples`. This fix accounts for this common package.
