### PR TITLE
updated to escape ampersands from paths

### DIFF
--- a/lib/demeteorizer.js
+++ b/lib/demeteorizer.js
@@ -13,13 +13,14 @@ const modulesNotInRegistry = [
 ];
 
 /**
- * Escapes spaces out of the specified path.
+ * Escapes special characters out of the specified path.
  * @param {String} filePath The path to escape.
  */
 var escapePath = function (filePath) {
   if (!filePath || filePath.length === 0) return filePath;
 
   filePath = filePath.replace(/ /g, '\\ ');
+  filePath = filePath.replace(/\&/g, '\\&');
   filePath = filePath.replace(/\(/g, '\\(');
   filePath = filePath.replace(/\)/g, '\\)');
   return filePath;


### PR DESCRIPTION
Replace ampersands in file paths with \& to allow the shell to correctly
access the directories.

Closes #102.