### PR TITLE
Skip folders called `test`

### DIFF
--- a/lib/demeteorizer.js
+++ b/lib/demeteorizer.js
@@ -242,8 +242,8 @@ Demeteorizer.prototype.findDependenciesInFolder = function (folder, inNodeModule
         }
       }
 
-      // Skip the examples directory.
-      if (file === 'examples' || file === 'samples') {
+      // Skip the examples, samples and tests directories.
+      if (file === 'examples' || file === 'samples' || file === 'test') {
         keepGoing = false;
       }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "keywords": [
     "meteor"
   ],
-  "version": "2.1.2",
+  "version": "2.1.3",
   "author": "Modulus <support@modulus.io>",
   "maintainers": [
     "Brandon Cannaday <brandon@modulus.io>",


### PR DESCRIPTION
Some packages, like Mozilla’s Add-On SDK and its dependees, use this
folder to store test node modules.

Ideally, there would be a way to detect if a module were local only,
and not add its entry to the `package.json`.

This fix also removes a considerable number of resolved but nonetheless
unnecessary packages from the `package.json` for Workpop.