### PR TITLE
updated to support windows versions

### DIFF
--- a/lib/demeteorizer.js
+++ b/lib/demeteorizer.js
@@ -113,13 +113,24 @@ Demeteorizer.prototype.getMeteorVersion = function (context, callback) {
     // If the length of the split is more than 2, the output includes some extra
     //    stuff so the return value should be based on the last line of text.
     var versionLines = stdout.split('\n');
+
     var versionText = versionLines.length > 2
       ? versionLines[versionLines.length - 2]
       : stdout;
 
-    // Split on space and take the second element because the version output is
-    //    `Meteor x.x.x.x`.
-    var version = versionText.split(' ')[1].trim();
+    var version;
+
+    // Supports two different version outputs: `Meteor x.x.x.x` or
+    //    `WINDOWS-PREVIEW@x.x.x.x`. Split on the correct char and trim any
+    //    extra whitespace.
+    if (versionText.indexOf('@') >= 0) {
+      version = versionText.split('@')[1].trim();
+    } else {
+      version = versionText.split(' ')[1].trim();
+    }
+
+    context.isWindows = versionText.toLowerCase().indexOf('windows') >= 0;
+
     var versionParts = version.split('.');
     context.meteorVersion = versionParts[0] + '.' + versionParts[1] + '.x';
 
@@ -160,9 +171,11 @@ Demeteorizer.prototype.getBundleCommand = function (context) {
 
   // Ignore any errors when attempting to determine the version. Newer versions
   //    of Meteor use invalid semantic versions; default to meteor bundle.
+  // Default to `meteor` if running on Windows.
   try {
     if (semver.lte(context.meteorVersion.replace('x', '0'), '0.8.0')
-        && fs.existsSync(smartJsonPath)) {
+        && fs.existsSync(smartJsonPath)
+        && !context.isWindows) {
       this.emit(
         'progress',
         'Found smart.json file, switching to Meteorite bundle.');

--- a/spec/demeteorizer-spec.js
+++ b/spec/demeteorizer-spec.js
@@ -47,6 +47,7 @@ describe('demeteorizer lib', function () {
 
       demeteorizer.getMeteorVersion(context, function () {
         context.meteorVersion.should.equal('0.9.x');
+        context.isWindows.should.be.false;
       });
     });
 
@@ -57,6 +58,7 @@ describe('demeteorizer lib', function () {
 
       demeteorizer.getMeteorVersion(context, function () {
         context.meteorVersion.should.equal('0.9.x');
+        context.isWindows.should.be.false;
       });
     });
 
@@ -69,6 +71,24 @@ describe('demeteorizer lib', function () {
           'Could not determine Meteor version. Make sure that Meteor is installed.'
         );
         done();
+      });
+    });
+
+    it('should get the correct version for Windows preview', function () {
+      cpStub.exec = sinon.stub().yields(null, 'WINDOWS-PREVIEW@0.3.0');
+
+      demeteorizer.getMeteorVersion(context, function () {
+        context.meteorVersion.should.equal('0.3.x');
+        context.isWindows.should.be.true;
+      });
+    });
+
+    it('should windows boolean for Windows preview', function () {
+      cpStub.exec = sinon.stub().yields(null, 'WINDOWS-PREVIEW@0.3.0');
+
+      demeteorizer.getMeteorVersion(context, function () {
+        context.meteorVersion.should.equal('0.3.x');
+        context.isWindows.should.be.true;
       });
     });
 
@@ -103,16 +123,29 @@ describe('demeteorizer lib', function () {
   describe('#getBundleCommand', function () {
     it('should choose meteor bundle for 0.9.x', function () {
       context.meteorVersion = '0.9.x';
+      context.isWindows = false;
+
       demeteorizer.getBundleCommand(context).should.equal('meteor');
     });
 
     it('should choose mrt bundle for 0.8.x', function () {
       context.meteorVersion = '0.8.x';
+      context.isWindows = false;
+
       demeteorizer.getBundleCommand(context).should.equal('mrt');
     });
 
     it('should choose meteor bundle for invalid versions', function () {
       context.meteorVersion = '1.0-rc.10';
+      context.isWindows = false;
+
+      demeteorizer.getBundleCommand(context).should.equal('meteor');
+    });
+
+    it('should choose meteor bundle for windows preview', function () {
+      context.meteorVersion = '0.3.x';
+      context.isWindows = true;
+
       demeteorizer.getBundleCommand(context).should.equal('meteor');
     });
   });


### PR DESCRIPTION
Correctly handle the WINDOWS-PREVIEW (and any version starting with
WINDOWS) as well as the @ symbol in the version.