### PR TITLE
Adds support for Windows

### DIFF
--- a/lib/demeteorizer.js
+++ b/lib/demeteorizer.js
@@ -454,12 +454,14 @@ Demeteorizer.prototype.deleteShrinkWraps = function (context, callback) {
     var files = fs.readdirSync(folder);
 
     files.forEach(function (file) {
-      var stats = fs.statSync(path.join(folder, file));
+      var stats = fs.statSync(path.resolve(folder, file));
 
       if (stats.isDirectory()) {
-        next(path.join(folder, file));
-      } else if (file === 'npm-shrinkwrap.json') {
-        fs.unlinkSync(path.join(folder, file));
+        return next(path.resolve(folder, file));
+      }
+
+      if (file === 'npm-shrinkwrap.json') {
+        return fs.unlinkSync(path.resolve(folder, file));
       }
     });
   }(context.options.output);

--- a/lib/demeteorizer.js
+++ b/lib/demeteorizer.js
@@ -5,7 +5,7 @@ var path         = require('path');
 var util         = require('util');
 
 var async        = require('async');
-var FsTools      = require('fs-tools');
+var rmdir        = require('rimraf');
 var semver       = require('semver');
 
 const modulesNotInRegistry = [
@@ -147,7 +147,7 @@ Demeteorizer.prototype.setupOutputFolder = function (context, callback) {
 
   if (fs.existsSync(output)) {
     this.emit('progress', 'Output folder exists, deleting...');
-    FsTools.remove(output, callback);
+    rmdir(output, callback);
   }
   else {
     callback();
@@ -437,7 +437,7 @@ Demeteorizer.prototype.deleteNodeModulesDir = function (folder) {
     var stat = fs.statSync(path.join(folder, file));
 
     if (stat.isDirectory() && file === 'node_modules') {
-      FsTools.removeSync(path.join(folder, file));
+      rmdir(path.join(folder, file), new Function());
     } else if (stat.isDirectory()) {
       this.deleteNodeModulesDir(path.join(folder, file));
     }
@@ -513,7 +513,7 @@ Demeteorizer.prototype.deleteDirectory = function (context, callback) {
 
   this.emit('progress', 'Deleting bundle directory.');
 
-  FsTools.remove(context.options.output, callback);
+  rmdir(context.options.output, callback);
 };
 
 module.exports = new Demeteorizer();

--- a/lib/demeteorizer.js
+++ b/lib/demeteorizer.js
@@ -461,7 +461,7 @@ Demeteorizer.prototype.deleteShrinkWraps = function (context, callback) {
       }
 
       if (file === 'npm-shrinkwrap.json') {
-        return fs.unlinkSync(path.resolve(folder, file));
+        return fs.unlink(path.resolve(folder, file), new Function());
       }
     });
   }(context.options.output);

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "async": "0.2.10",
     "commander": "1.1.1",
-    "fs-tools": "0.2.11",
+    "rimraf": "2.3.2",
     "semver": "3.0.1"
   },
   "devDependencies": {

--- a/spec/demeteorizer-spec.js
+++ b/spec/demeteorizer-spec.js
@@ -83,7 +83,7 @@ describe('demeteorizer lib', function () {
       });
     });
 
-    it('should windows boolean for Windows preview', function () {
+    it('should set windows boolean for Windows preview', function () {
       cpStub.exec = sinon.stub().yields(null, 'WINDOWS-PREVIEW@0.3.0');
 
       demeteorizer.getMeteorVersion(context, function () {


### PR DESCRIPTION
Corrects a handful of issues:

* Use `fs.unlink` in favor of `fs.unlinkSync` which doesn't work on Windows
* Use `rimraf` in favor of `fs-tools` which doesn't work on Windows
* Uss `path.resolve` in favor of `path.join` which may or may not actually fix anything

Works for Meteor 1.1(.1) on both Windows and OS X.
Closes #118