### PR TITLE
updated to quote paths rather than escape them

### DIFF
--- a/lib/demeteorizer.js
+++ b/lib/demeteorizer.js
@@ -15,20 +15,6 @@ const modulesNotInRegistry = [
 ];
 
 /**
- * Escapes special characters out of the specified path.
- * @param {String} filePath The path to escape.
- */
-var escapePath = function (filePath) {
-  if (!filePath || filePath.length === 0) return filePath;
-
-  filePath = filePath.replace(/ /g, '\\ ');
-  filePath = filePath.replace(/\&/g, '\\&');
-  filePath = filePath.replace(/\(/g, '\\(');
-  filePath = filePath.replace(/\)/g, '\\)');
-  return filePath;
-};
-
-/**
  * Demeteorizer constructor function. Derives from EventEmitter.
  *
  * @constructor
@@ -205,12 +191,12 @@ Demeteorizer.prototype.bundle = function (context, callback) {
   }
 
   // meteor bundle --debug --version 0.x.x --directory ./
-  var bundleCommand = util.format('cd %s && %s bundle %s %s --directory %s',
-    escapePath(context.options.input),
+  var bundleCommand = util.format('cd "%s" && %s bundle %s %s --directory "%s"',
+    context.options.input,
     cmd,
     context.options.debug ? '--debug' : '',
     release ? '--release ' + release : '',
-    escapePath(context.options.output)
+    context.options.output
   );
 
   childProcess.exec(bundleCommand, function (err, stdout, stderr) {
@@ -509,9 +495,9 @@ Demeteorizer.prototype.createTarball = function (context, callback) {
   this.emit('progress', 'Creating tarball.');
 
   var cmd = util.format(
-    'tar czPf %s -C %s .',
-    escapePath(context.options.tarball),
-    escapePath(context.options.output)
+    'tar czPf "%s" -C "%s" .',
+    context.options.tarball,
+    context.options.output
   );
 
   childProcess.exec(cmd, function (err, stdout) {

--- a/spec/demeteorizer-spec.js
+++ b/spec/demeteorizer-spec.js
@@ -172,7 +172,7 @@ describe('demeteorizer lib', function () {
 
       demeteorizer.createTarball(context, function () {
         cpStub.exec
-          .calledWith('tar czPf test.tar.gz -C .demeteorized .')
+          .calledWith('tar czPf "test.tar.gz" -C ".demeteorized" .')
           .should.be.true;
 
         done();


### PR DESCRIPTION
Just wrap paths in commands in quotes rather than attempting to escape every
special character.

Closes #134