### PR TITLE
Fix for issue 122

### DIFF
--- a/lib/demeteorizer.js
+++ b/lib/demeteorizer.js
@@ -14,6 +14,8 @@ const modulesNotInRegistry = [
   'forge-nodejs-example'
 ];
 
+const MAXBUFFERSIZE = 1024 * 1024 ;   // Allow a full Meg of data on stdout/stderr
+
 /**
  * Demeteorizer constructor function. Derives from EventEmitter.
  *
@@ -83,7 +85,7 @@ Demeteorizer.prototype.setupPaths = function (options) {
 Demeteorizer.prototype.getMeteorVersion = function (context, callback) {
   this.emit('progress', 'Determining Meteor version...');
 
-  childProcess.exec('meteor --version', function (err, stdout) {
+  childProcess.exec('meteor --version', { maxBuffer : MAXBUFFERSIZE } , function (err, stdout) {
     if (err) {
       return callback(err);
     }
@@ -199,7 +201,7 @@ Demeteorizer.prototype.bundle = function (context, callback) {
     context.options.output
   );
 
-  childProcess.exec(bundleCommand, function (err, stdout, stderr) {
+  childProcess.exec(bundleCommand, { maxBuffer : MAXBUFFERSIZE } , function (err, stdout, stderr) {
     if (err) {
       return callback(err);
     }
@@ -500,7 +502,7 @@ Demeteorizer.prototype.createTarball = function (context, callback) {
     context.options.output
   );
 
-  childProcess.exec(cmd, function (err, stdout) {
+  childProcess.exec(cmd, { maxBuffer : MAXBUFFERSIZE } , function (err, stdout) {
 
     if (stdout) {
       this.emit('progress', stdout);


### PR DESCRIPTION
Increased the maxBuffer size for stdout/stderr for each of the .exec() calls made to 1M from 200K.