### PR TITLE
Fix# 143 - EPERM error in Windows

### DIFF
--- a/lib/update-package.js
+++ b/lib/update-package.js
@@ -33,5 +33,4 @@ module.exports = function (options, done) {
   //
   Fs.chmodSync(packagePath, '0644') ;
   Fs.writeFile(packagePath, JSON.stringify(packageContents, null, 2), done);
-  Fs.chmodSync(packagePath, '0444') ;
 };

--- a/lib/update-package.js
+++ b/lib/update-package.js
@@ -31,6 +31,13 @@ module.exports = function (options, done) {
   // The generated package.json is read-only, but removing it prior to writing
   //    will allow updates.
   //
+  // Node 0.10.xx + Windows Hack .. Windows does not allow an unlink of a Read-Only file .. 
+  // So we chmod it to be rw by owner... 
+  // This was fixed in node 0.12 + but still is an issue in 0.10.XX which Meteor uses..
+  if ( FindNodeVersion(options).substring(0,4) === "0.10" && process.platform === "win32") {
+  	Fs.chmodSync( packagePath, "0644") ;
+  }
+
   Fs.unlinkSync(packagePath);
   Fs.writeFile(packagePath, JSON.stringify(packageContents, null, 2), done);
 };

--- a/lib/update-package.js
+++ b/lib/update-package.js
@@ -31,7 +31,7 @@ module.exports = function (options, done) {
   // Change the file permissions so we can over-write the package. Then we'll write the package
   // and then change the file permissions back to read-only.
   //
-	Fs.chmodSync( packagePath, "0644" ) ;
-  Fs.writeFile( packagePath, JSON.stringify(packageContents, null, 2), done);
-	Fs.chmodSync( packagePath, "0444" ) ;
+  Fs.chmodSync(packagePath, '0644') ;
+  Fs.writeFile(packagePath, JSON.stringify(packageContents, null, 2), done);
+  Fs.chmodSync(packagePath, '0444') ;
 };

--- a/lib/update-package.js
+++ b/lib/update-package.js
@@ -28,16 +28,10 @@ module.exports = function (options, done) {
   Hoek.merge(packageContents, options.json || {});
 
   //
-  // The generated package.json is read-only, but removing it prior to writing
-  //    will allow updates.
+  // Change the file permissions so we can over-write the package. Then we'll write the package
+  // and then change the file permissions back to read-only.
   //
-  // Node 0.10.xx + Windows Hack .. Windows does not allow an unlink of a Read-Only file .. 
-  // So we chmod it to be rw by owner... 
-  // This was fixed in node 0.12 + but still is an issue in 0.10.XX which Meteor uses..
-  if ( FindNodeVersion(options).substring(0,4) === "0.10" && process.platform === "win32") {
-  	Fs.chmodSync( packagePath, "0644") ;
-  }
-
-  Fs.unlinkSync(packagePath);
-  Fs.writeFile(packagePath, JSON.stringify(packageContents, null, 2), done);
+	Fs.chmodSync( packagePath, "0644" ) ;
+  Fs.writeFile( packagePath, JSON.stringify(packageContents, null, 2), done);
+	Fs.chmodSync( packagePath, "0444" ) ;
 };

--- a/test/update-package.js
+++ b/test/update-package.js
@@ -45,7 +45,7 @@ describe('update-package', function () {
     before(function (done) {
       fsStub.existsSync = Sinon.stub().returns(true);
       fsStub.readFileSync = Sinon.stub().returns('{}');
-      fsStub.unlinkSync = Sinon.stub();
+      fsStub.chmodSync = Sinon.stub();
       fsStub.writeFile = Sinon.stub().yields(null);
       done();
     });
@@ -62,7 +62,7 @@ describe('update-package', function () {
     before(function (done) {
       fsStub.existsSync = Sinon.stub().returns(true);
       fsStub.readFileSync = Sinon.stub().returns('{}');
-      fsStub.unlinkSync = Sinon.stub();
+      fsStub.chmodSync = Sinon.stub();
       fsStub.writeFile = Sinon.stub().yields(null);
       done();
     });


### PR DESCRIPTION
This is just a simple kludge to remove the error when demeteorizing on Windows with an older node version. Seems to work in my testing.