### PR TITLE
Update error logging when conversion fails.

### DIFF
--- a/bin/demeteorizer
+++ b/bin/demeteorizer
@@ -43,7 +43,7 @@ var options = {
 
 Demteorizer(options, function (err) {
   if (err) {
-    console.error(err.message);
+    console.error(err instanceof Error ? err.message : err);
     return process.exit(1);
   }
 


### PR DESCRIPTION
Check that the error returned is an error (and has a `message`
property) when logging the failed result. In some places, Meteor
returns a string and this would output `undefined`.