### PR TITLE
Update travis config to use later version of npm.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - '0.12'
   - '4'
 before_install:
-  - 'npm install npm@1.4.28 -g && npm install codeclimate-test-reporter -g'
+  - 'npm -g install npm@latest-2npm install codeclimate-test-reporter -g'
 addons:
   code_climate:
     repo_token: c8ea2e0ac816cb09d3c8a2bdf92394f81908dcbe858ec70fd1bcbac2c8cfb030

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - '0.12'
   - '4'
 before_install:
-  - 'npm -g install npm@latest-2npm install codeclimate-test-reporter -g'
+  - 'npm -g install npm@latest-2 && npm install codeclimate-test-reporter -g'
 addons:
   code_climate:
     repo_token: c8ea2e0ac816cb09d3c8a2bdf92394f81908dcbe858ec70fd1bcbac2c8cfb030

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: node_js
 node_js:
-  - '0.10'
   - '0.12'
   - '4'
 before_install:
-  - 'npm -g install npm@latest-2 && npm install codeclimate-test-reporter -g'
+  - 'npm install npm@latest -g && npm install codeclimate-test-reporter -g'
 addons:
   code_climate:
     repo_token: c8ea2e0ac816cb09d3c8a2bdf92394f81908dcbe858ec70fd1bcbac2c8cfb030


### PR DESCRIPTION
The rollback of npm is no longer necessary and is only causing builds to fail,
this corrects that issue.