### PR TITLE
Update some dependencies and fix issues with running tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,8 +2,6 @@
     "extends": "modulus",
     "rules": {
         "no-sync": 0,
-        "no-undefined": 0,
-        "semi-spacing": 2,
-        "semi": 2
+        "no-undefined": 0
     }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - '0.12'
   - '4'
+  - '6'
 before_install:
   - 'npm install npm@latest -g && npm install codeclimate-test-reporter -g'
 addons:

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -1,1 +1,1 @@
-exports.spawn = require('win-spawn');
+exports.spawn = require('cross-spawn');

--- a/lib/find-node-version.js
+++ b/lib/find-node-version.js
@@ -23,7 +23,10 @@ module.exports = function (options) {
     //    version of the project.
     Fs.readFileSync(bootPath).toString().split('\n').some(function (line) {
       if (line.indexOf('MIN_NODE_VERSION') >= 0) {
+        /* eslint-disable no-magic-numbers */
         version = line.split(' ')[3].replace(/[v;']/g, '');
+        /* eslint-enable no-magic-numbers */
+
         return true;
       }
     });

--- a/package.json
+++ b/package.json
@@ -23,21 +23,22 @@
     "url": "https://github.com/OnModulus/demeteorizer"
   },
   "dependencies": {
-    "commander": "2.8.1",
-    "hoek": "2.x.x",
-    "win-spawn": "2.0.0"
+    "commander": "2.9.0",
+    "hoek": "4.x.x",
+    "cross-spawn": "3.0.1"
   },
   "devDependencies": {
-    "code": "1.x.x",
-    "lab": "5.x.x",
-    "proxyquire": "1.7.1",
-    "sinon": "1.16.1",
-    "eslint": "1.3.1",
-    "eslint-plugin-hapi": "1.2.0",
-    "eslint-config-modulus": "*"
+    "code": "2.x.x",
+    "lab": "10.x.x",
+    "proxyquire": "1.7.9",
+    "sinon": "1.17.4",
+    "eslint": "2.10.2",
+    "eslint-plugin-hapi": "4.0.0",
+    "eslint-plugin-promise": "1.1.0",
+    "eslint-config-modulus": "0.6.0"
   },
   "scripts": {
-    "test": "lab --threshold 100",
+    "test": "lab --threshold 100 --lint",
     "gen-coverage": "lab --coverage --reporter lcov --output coverage/lcov.info"
   },
   "main": "./lib/demeteorizer",


### PR DESCRIPTION
There's a lot going on here:

 - Uses a hard version of the Modulus eslint config
 - Moves to the new spawn module for Windows
 - Updates lab/code
 - Now actually runs the lint
 - Removes 0.12 from CI

Still uses the Modulus eslint config.