### PR TITLE
Add feature to support setting node and npm version through flags

### DIFF
--- a/bin/demeteorizer
+++ b/bin/demeteorizer
@@ -27,7 +27,7 @@ Program
     'Node version set in generated package.json')
   .option(
     '--npm-version <version>',
-    'NPM version set in generated package.json')
+    'npm version set in generated package.json (defaults to latest)')
   .parse(process.argv);
 
 console.log('Demeteorizing application...');

--- a/bin/demeteorizer
+++ b/bin/demeteorizer
@@ -22,6 +22,12 @@ Program
   .option(
     '-j, --json <json>',
     'JSON data to be merged into the generated package.json')
+  .option(
+    '--node-version <version>',
+    'Node version set in generated package.json')
+  .option(
+    '--npm-version <version>',
+    'NPM version set in generated package.json')
   .parse(process.argv);
 
 console.log('Demeteorizing application...');
@@ -42,7 +48,9 @@ var options = {
   input: process.cwd(),
   directory: Program.output,
   json: Program.json,
-  architecture: Program.architecture
+  architecture: Program.architecture,
+  npmVersion: Program.npmVersion,
+  nodeVersion: Program.nodeVersion
 };
 
 Demteorizer(options, function (err) {

--- a/lib/find-node-version.js
+++ b/lib/find-node-version.js
@@ -11,6 +11,8 @@ module.exports = function (options) {
   Hoek.assert(options !== undefined, 'options is required');
   Hoek.assert(Fs.existsSync(options.directory), 'Output directory not found');
 
+  if (typeof options.nodeVersion !== 'undefined') return options.nodeVersion;
+
   bootPath = Path.resolve(
     options.directory,
     'bundle',

--- a/lib/update-package.js
+++ b/lib/update-package.js
@@ -23,7 +23,11 @@ module.exports = function (options, done) {
   //
   packageContents = JSON.parse(Fs.readFileSync(packagePath));
 
-  packageContents.engines = { node: FindNodeVersion(options) };
+  packageContents.engines = {
+    node: FindNodeVersion(options),
+    npm: typeof options.npmVersion !== 'undefined' ? options.npmVersion : 'latest'
+  };
+
   packageContents.main = '../../main.js';
   packageContents.scripts = { start: 'node ../../main' };
 

--- a/test/find-node-version.js
+++ b/test/find-node-version.js
@@ -59,6 +59,12 @@ describe('find-node-version', function () {
       done();
     });
 
+    it('finds node version from options.nodeVersion', function (done) {
+      expect(FindVersion({ directory: '', nodeVersion: '4.2.0' }))
+        .to.equal('4.2.0');
+      done();
+    });
+
     it('finds the node version from boot.js', function (done) {
       expect(FindVersion({ directory: '' })).to.equal('0.10.36');
       done();

--- a/test/find-node-version.js
+++ b/test/find-node-version.js
@@ -59,7 +59,7 @@ describe('find-node-version', function () {
       done();
     });
 
-    it('finds node version from options.nodeVersion', function (done) {
+    it('sets node version from --node-version', function (done) {
       expect(FindVersion({ directory: '', nodeVersion: '4.2.0' }))
         .to.equal('4.2.0');
       done();

--- a/test/update-package.js
+++ b/test/update-package.js
@@ -73,13 +73,36 @@ describe('update-package', function () {
         var json = [
           '{',
           '  "engines": {',
-          '    "node": "0.10.33"',
+          '    "node": "0.10.33",',
+          '    "npm": "latest"',
           '  },',
           '  "main": "../../main.js",',
           '  "scripts": {',
           '    "start": "node ../../main"',
           '  },',
           '  "test": true',
+          '}'].join('\n');
+
+        expect(fsStub.writeFile.calledWith(path, json)).to.be.true();
+        done();
+      });
+    });
+  });
+
+  describe('uses npm version specified from options', function () {
+    it('sets npm version using options.npmVersion', function (done) {
+      UpdatePackage({ directory: '', npmVersion: '3.9.0' }, function () {
+        var path = Path.resolve('./bundle/programs/server/package.json');
+        var json = [
+          '{',
+          '  "engines": {',
+          '    "node": "0.10.33",',
+          '    "npm": "3.9.0"',
+          '  },',
+          '  "main": "../../main.js",',
+          '  "scripts": {',
+          '    "start": "node ../../main"',
+          '  }',
           '}'].join('\n');
 
         expect(fsStub.writeFile.calledWith(path, json)).to.be.true();


### PR DESCRIPTION
- Set node version in generated package.json through CLI flag `--node-version`
- Set npm version in generated package.json through CLI flag `--npm-version`. If no npm version is specified then `npm` is set to `latest` in generated `package.json`.

Closes #172 