### PR TITLE
Add the ability to send `--verbose` to build.

### DIFF
--- a/bin/demeteorizer
+++ b/bin/demeteorizer
@@ -23,6 +23,9 @@ Program
     '-j, --json <json>',
     'JSON data to be merged into the generated package.json')
   .option(
+    '-v, --verbose',
+    'Output extra build information')
+  .option(
     '--node-version <version>',
     'Node version set in generated package.json')
   .option(
@@ -49,6 +52,7 @@ var options = {
   directory: Program.output,
   json: Program.json,
   architecture: Program.architecture,
+  verbose: Boolean(Program.verbose),
   npmVersion: Program.npmVersion,
   nodeVersion: Program.nodeVersion
 };

--- a/lib/build.js
+++ b/lib/build.js
@@ -32,6 +32,7 @@ module.exports = function (options, done) {
 
   if (options.debug) args.push('--debug')
   if (options.serverOnly) args.push('--server-only')
+  if (options.verbose) args.push('--verbose')
 
   build = Exec.spawn('meteor', args, { cwd: options.input, stdio: 'inherit' })
 

--- a/test/build.js
+++ b/test/build.js
@@ -99,6 +99,23 @@ describe('build', function () {
     emitter.emit('close', 0)
   })
 
+  it('includes verbose when provided', function (done) {
+    Build({ verbose: true }, function () {
+      expect(cpStub.spawn.calledWith('meteor', [
+        'build',
+        '--server',
+        'localhost',
+        '--directory',
+        '.demeteorized',
+        '--verbose'
+      ])).to.be.true()
+
+      done()
+    })
+
+    emitter.emit('close', 0)
+  })
+
   it('returns an error on failed exit', function (done) {
     Build({}, function (err) {
       expect(err.message).to.equal('Conversion failed.')


### PR DESCRIPTION
New CLI flag for passing `--verbose` to the Meteor build command.
Shout out to @jwall149 for the original version of this code <3