### PR TITLE
Es2015

### DIFF
--- a/bin/demeteorizer
+++ b/bin/demeteorizer
@@ -53,7 +53,7 @@ var options = {
   nodeVersion: Program.nodeVersion
 };
 
-Demteorizer(options, function (err) {
+Demteorizer(options, (err) => {
   if (err) {
     console.error(err instanceof Error ? err.message : err);
     return process.exit(1);

--- a/lib/build.js
+++ b/lib/build.js
@@ -14,7 +14,7 @@ const defaults = {
 //    directory - The output directory (defaults to .demeteorized).
 //    architecture - Architecture build target.
 //
-module.exports = function (options, done) {
+module.exports = (options, done) => {
   var args, build;
 
   options = Hoek.applyToDefaults(defaults, options);
@@ -35,11 +35,11 @@ module.exports = function (options, done) {
 
   build = Exec.spawn('meteor', args, { cwd: options.input, stdio: 'inherit' });
 
-  build.on('error', function (err) {
+  build.on('error', (err) => {
     done(err);
   });
 
-  build.on('close', function (code) {
+  build.on('close', code => {
     if (code !== 0) return done(new Error('Conversion failed.'));
     done();
   });

--- a/lib/build.js
+++ b/lib/build.js
@@ -46,7 +46,7 @@ module.exports = (options, done) => {
     done(err)
   })
 
-  build.on('close', code => {
+  build.on('close', (code) => {
     if (code !== 0) return done(new Error('Conversion failed.'))
     done()
   })

--- a/lib/demeteorizer.js
+++ b/lib/demeteorizer.js
@@ -3,10 +3,10 @@ const Hoek = require('hoek');
 const Build = require('./build');
 const UpdatePackage = require('./update-package');
 
-module.exports = function (options, done) {
+module.exports = (options, done) => {
   Hoek.assert(options !== undefined, 'You must provide a valid options object');
 
-  Build(options, function (err) {
+  Build(options, (err) => {
     if (err) return done(err);
 
     UpdatePackage(options, done);

--- a/lib/find-node-version.js
+++ b/lib/find-node-version.js
@@ -2,16 +2,17 @@ const Fs = require('fs');
 const Path = require('path');
 
 const Hoek = require('hoek');
+const Semver = require('semver');
 
 const DEFAULT_NODE_VERSION = '0.10.33';
 
-module.exports = function (options) {
+module.exports = options => {
   var version, bootPath;
 
   Hoek.assert(options !== undefined, 'options is required');
   Hoek.assert(Fs.existsSync(options.directory), 'Output directory not found');
 
-  if (typeof options.nodeVersion !== 'undefined') return options.nodeVersion;
+  if (Semver.valid(options.nodeVersion)) return options.nodeVersion;
 
   bootPath = Path.resolve(
     options.directory,
@@ -23,7 +24,7 @@ module.exports = function (options) {
   try {
     // Read boot.js to find the MIN_NODE_VERSION; use that version as the node
     //    version of the project.
-    Fs.readFileSync(bootPath).toString().split('\n').some(function (line) {
+    Fs.readFileSync(bootPath).toString().split('\n').some(line => {
       if (line.indexOf('MIN_NODE_VERSION') >= 0) {
         /* eslint-disable no-magic-numbers */
         version = line.split(' ')[3].replace(/[v;']/g, '');

--- a/lib/find-node-version.js
+++ b/lib/find-node-version.js
@@ -5,7 +5,7 @@ const Hoek = require('hoek')
 
 const DEFAULT_NODE_VERSION = '0.10.33'
 
-module.exports = options => {
+module.exports = (options) => {
   var version, bootPath
 
   Hoek.assert(options !== undefined, 'options is required')
@@ -23,7 +23,7 @@ module.exports = options => {
   try {
     // Read boot.js to find the MIN_NODE_VERSION; use that version as the node
     //    version of the project.
-    Fs.readFileSync(bootPath).toString().split('\n').some(line => {
+    Fs.readFileSync(bootPath).toString().split('\n').some((line) => {
       if (line.indexOf('MIN_NODE_VERSION') >= 0) {
         /* eslint-disable no-magic-numbers */
         version = line.split(' ')[3].replace(/[v;']/g, '')

--- a/lib/update-package.js
+++ b/lib/update-package.js
@@ -5,7 +5,7 @@ const Hoek = require('hoek');
 
 const FindNodeVersion = require('./find-node-version');
 
-module.exports = function (options, done) {
+module.exports = (options, done) => {
   var packagePath, packageContents;
 
   Hoek.assert(options !== undefined, 'options is required');

--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
   },
   "dependencies": {
     "commander": "2.9.0",
+    "cross-spawn": "3.0.1",
     "hoek": "4.x.x",
-    "cross-spawn": "3.0.1"
+    "semver": "5.1.0"
   },
   "devDependencies": {
     "code": "2.x.x",

--- a/test/build.js
+++ b/test/build.js
@@ -17,22 +17,22 @@ var beforeEach = lab.beforeEach;
 var it = lab.it;
 var expect = Code.expect;
 
-describe('build', function () {
+describe('build', () => {
   var emitter;
 
-  beforeEach(function (done) {
+  beforeEach((done) => {
     emitter = new EventEmitter();
     cpStub.spawn = Sinon.stub().returns(emitter);
     done();
   });
 
-  it('exports a function', function (done) {
+  it('exports a function', (done) => {
     expect(Build).to.be.a.function();
     done();
   });
 
-  it('defaults options', function (done) {
-    Build({}, function () {
+  it('defaults options', (done) => {
+    Build({}, () => {
       expect(cpStub.spawn.calledWith('meteor', [
         'build',
         '--server',
@@ -47,8 +47,8 @@ describe('build', function () {
     emitter.emit('close', 0);
   });
 
-  it('overrides architecture when provided', function (done) {
-    Build({ architecture: 'os.linux.x86_64' }, function () {
+  it('overrides architecture when provided', (done) => {
+    Build({ architecture: 'os.linux.x86_64' }, () => {
       expect(cpStub.spawn.calledWith('meteor', [
         'build',
         '--server',
@@ -65,8 +65,8 @@ describe('build', function () {
     emitter.emit('close', 0);
   });
 
-  it('includes debug when provided', function (done) {
-    Build({ debug: true }, function () {
+  it('includes debug when provided', (done) => {
+    Build({ debug: true }, () => {
       expect(cpStub.spawn.calledWith('meteor', [
         'build',
         '--server',
@@ -82,8 +82,8 @@ describe('build', function () {
     emitter.emit('close', 0);
   });
 
-  it('includes server only when provided', function (done) {
-    Build({ serverOnly: true }, function () {
+  it('includes server only when provided', (done) => {
+    Build({ serverOnly: true }, () => {
       expect(cpStub.spawn.calledWith('meteor', [
         'build',
         '--server',
@@ -99,8 +99,8 @@ describe('build', function () {
     emitter.emit('close', 0);
   });
 
-  it('returns an error on failed exit', function (done) {
-    Build({}, function (err) {
+  it('returns an error on failed exit', (done) => {
+    Build({}, (err) => {
       expect(err.message).to.equal('Conversion failed.');
 
       done();
@@ -109,8 +109,8 @@ describe('build', function () {
     emitter.emit('close', 1);
   });
 
-  it('returns an error when the command fails', function (done) {
-    Build({}, function (err) {
+  it('returns an error when the command fails', (done) => {
+    Build({}, (err) => {
       expect(err.message).to.equal('failed');
 
       done();

--- a/test/find-node-version.js
+++ b/test/find-node-version.js
@@ -15,23 +15,23 @@ var before = lab.beforeEach;
 var it = lab.it;
 var expect = Code.expect;
 
-describe('find-node-version', function () {
-  describe('initialization', function () {
-    it('fails if no options object is provided', function (done) {
-      expect(function () {
+describe('find-node-version', () => {
+  describe('initialization', () => {
+    it('fails if no options object is provided', (done) => {
+      expect(() => {
         FindVersion();
       }).to.throw();
 
       done();
     });
 
-    before(function (done) {
+    before((done) => {
       fsStub.existsSync = Sinon.stub().returns(false);
       done();
     });
 
-    it('fails if output directory does not exist', function (done) {
-      expect(function () {
+    it('fails if output directory does not exist', (done) => {
+      expect(() => {
         FindVersion({ directory: '' });
       }).to.throw();
 
@@ -39,8 +39,8 @@ describe('find-node-version', function () {
     });
   });
 
-  describe('successfully', function () {
-    before(function (done) {
+  describe('successfully', () => {
+    before((done) => {
       fsStub.existsSync = Sinon.stub().returns(true);
       fsStub.readFileSync = Sinon.stub().returns([
         'var Fiber = require("fibers");',
@@ -59,39 +59,39 @@ describe('find-node-version', function () {
       done();
     });
 
-    it('sets node version from --node-version', function (done) {
+    it('sets node version from --node-version', (done) => {
       expect(FindVersion({ directory: '', nodeVersion: '4.2.0' }))
         .to.equal('4.2.0');
       done();
     });
 
-    it('finds the node version from boot.js', function (done) {
+    it('finds the node version from boot.js', (done) => {
       expect(FindVersion({ directory: '' })).to.equal('0.10.36');
       done();
     });
   });
 
-  describe('unsuccessfully', function () {
-    before(function (done) {
+  describe('unsuccessfully', () => {
+    before((done) => {
       fsStub.existsSync = Sinon.stub().returns(true);
       fsStub.readFileSync = Sinon.stub().returns('');
       done();
     });
 
-    it('finds the node version from boot.js', function (done) {
+    it('finds the node version from boot.js', (done) => {
       expect(FindVersion({ directory: '' })).to.equal('0.10.33');
       done();
     });
   });
 
-  describe('throws trying to', function () {
-    before(function (done) {
+  describe('throws trying to', () => {
+    before((done) => {
       fsStub.existsSync = Sinon.stub().returns(true);
       fsStub.readFileSync = Sinon.stub().throws();
       done();
     });
 
-    it('find the node version from boot.js', function (done) {
+    it('find the node version from boot.js', (done) => {
       expect(FindVersion({ directory: '' })).to.equal('0.10.33');
       done();
     });

--- a/test/update-package.js
+++ b/test/update-package.js
@@ -17,32 +17,32 @@ var before = lab.beforeEach;
 var it = lab.it;
 var expect = Code.expect;
 
-describe('update-package', function () {
-  describe('fails', function () {
-    before(function (done) {
+describe('update-package', () => {
+  describe('fails', () => {
+    before((done) => {
       fsStub.existsSync = Sinon.stub().returns(false);
       done();
     });
 
-    it('if no options object is provided', function (done) {
-      expect(function () {
+    it('if no options object is provided', (done) => {
+      expect(() => {
         UpdatePackage();
       }).to.throw();
 
       done();
     });
 
-    it('if output directory does not exist', function (done) {
-      expect(function () {
-        UpdatePackage({ directory: '' }, function () {});
+    it('if output directory does not exist', (done) => {
+      expect(() => {
+        UpdatePackage({ directory: '' }, () => {});
       }).to.throw();
 
       done();
     });
   });
 
-  describe('successfully', function () {
-    before(function (done) {
+  describe('successfully', () => {
+    before((done) => {
       fsStub.existsSync = Sinon.stub().returns(true);
       fsStub.readFileSync = Sinon.stub().returns('{}');
       fsStub.chmodSync = Sinon.stub();
@@ -50,16 +50,16 @@ describe('update-package', function () {
       done();
     });
 
-    it('creates a valid package.json', function (done) {
-      UpdatePackage({ directory: '' }, function () {
+    it('creates a valid package.json', (done) => {
+      UpdatePackage({ directory: '' }, () => {
         expect(fsStub.writeFile.called).to.be.true();
         done();
       });
     });
   });
 
-  describe('merges json from options into package.json', function () {
-    before(function (done) {
+  describe('merges json from options into package.json', () => {
+    before((done) => {
       fsStub.existsSync = Sinon.stub().returns(true);
       fsStub.readFileSync = Sinon.stub().returns('{}');
       fsStub.chmodSync = Sinon.stub();
@@ -67,8 +67,8 @@ describe('update-package', function () {
       done();
     });
 
-    it('creates a valid package.json', function (done) {
-      UpdatePackage({ directory: '', json: { test: true } }, function () {
+    it('creates a valid package.json', (done) => {
+      UpdatePackage({ directory: '', json: { test: true } }, () => {
         var path = Path.resolve('./bundle/programs/server/package.json');
         var json = [
           '{',
@@ -89,9 +89,9 @@ describe('update-package', function () {
     });
   });
 
-  describe('uses npm version specified from options', function () {
-    it('sets npm version using options.npmVersion', function (done) {
-      UpdatePackage({ directory: '', npmVersion: '3.9.0' }, function () {
+  describe('uses npm version specified from options', () => {
+    it('sets npm version using options.npmVersion', (done) => {
+      UpdatePackage({ directory: '', npmVersion: '3.9.0' }, () => {
         var path = Path.resolve('./bundle/programs/server/package.json');
         var json = [
           '{',


### PR DESCRIPTION
Update pieces of demeteorizer to better take advantage of ES6/ES2015. This mostly just includes arrow functions.

Demeteorizer is expected to run under the LTS version of node (4.6.0) so all tests were run with that version.