### PR TITLE
Adjusts tests to work with Windows.

### DIFF
--- a/test/find-node-version.js
+++ b/test/find-node-version.js
@@ -25,8 +25,8 @@ describe('find-node-version', () => {
 
   beforeEach((done) => {
     options = {
-      directory: process.env.PWD,
-      input: process.env.PWD
+      directory: process.cwd(),
+      input: process.cwd()
     }
 
     done()

--- a/test/find-npm-version.js
+++ b/test/find-npm-version.js
@@ -19,8 +19,8 @@ describe('find-npm-version', () => {
 
   beforeEach((done) => {
     options = {
-      directory: process.env.PWD,
-      input: process.env.PWD
+      directory: process.cwd(),
+      input: process.cwd()
     }
 
     done()

--- a/test/update-package.js
+++ b/test/update-package.js
@@ -23,9 +23,9 @@ describe('update-package', () => {
 
   beforeEach((done) => {
     options = {
-      directory: process.env.PWD,
+      directory: process.cwd(),
       nodeVersion: '4.2.0',
-      input: process.env.PWD,
+      input: process.cwd(),
       json: { test: true },
       npmVersion: '3.9.0'
     }


### PR DESCRIPTION
`process.env.CWD` doesn't work as expected on Windows, this changes the tests
to use `process.cwd()` instead.

There are no functional changes, I just needed the tests to pass. :)